### PR TITLE
Fixed problem with types of PayerCost type

### DIFF
--- a/src/coreMethods/util/types.ts
+++ b/src/coreMethods/util/types.ts
@@ -15,6 +15,9 @@ export interface PayerCost {
   reimbursement_rate?: unknown;
   max_allowed_amount: number;
   payment_method_option_id: string;
+  installment_amount: number;
+  recommended_message: string;
+  total_amount: number;
 }
 
 export type Identification = {


### PR DESCRIPTION
When i integrating your lib with typescript and I noticed some fields that are in the object but are not in the types. 

Follow Pr.

Thanks!