### PR TITLE
Feature/brand brick

### DIFF
--- a/examples/bricks/BrandBrick/0-Simple.tsx
+++ b/examples/bricks/BrandBrick/0-Simple.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Brand from '../../../src/bricks/brand';
+
+import initMercadoPago from '../../../src/mercadoPago/initMercadoPago';
+
+initMercadoPago('TEST-bfe30303-c7de-4da3-b765-c4be61b4f88b', {
+  locale: 'es-AR',
+});
+
+const ExampleSimpleBrandBrick = () => {
+  return <Brand />;
+};
+
+export default ExampleSimpleBrandBrick;

--- a/examples/bricks/BrandBrick/1-Visual-Customization.tsx
+++ b/examples/bricks/BrandBrick/1-Visual-Customization.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Brand from '../../../src/bricks/brand';
+
+import initMercadoPago from '../../../src/mercadoPago/initMercadoPago';
+
+initMercadoPago('TEST-bfe30303-c7de-4da3-b765-c4be61b4f88b', {
+  locale: 'es-AR',
+});
+
+const ExampleSimpleBrandBrick = () => {
+  return (
+    <Brand
+      customization={{
+        text: {
+          align: 'center',
+          valueProp: 'payment_methods_logos',
+          useCustomFont: true,
+          size: 'large',
+          fontWeight: 'semibold',
+          color: 'inverted',
+        },
+        paymentMethods: {
+          excludedPaymentMethods: ['master'],
+          excludedPaymentTypes: ['ticket'],
+          maxInstallments: 4,
+          interestFreeInstallments: false,
+        },
+        visual: {
+          hideMercadoPagoLogo: false,
+          contentAlign: 'center',
+          backgroundColor: 'mercado_pago_primary',
+          border: true,
+          borderColor: 'dark',
+          borderWidth: '2px',
+          borderRadius: '10px',
+          verticalPadding: '10px',
+          horizontalPadding: '10px',
+        },
+      }}
+      onReady={() => console.log('Brick is ready!')}
+    />
+  );
+};
+
+export default ExampleSimpleBrandBrick;

--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -31,6 +31,9 @@ declare global {
     statusScreenBrickController: {
       unmount: () => void;
     };
+    brandBrickController: {
+      unmount: () => void;
+    };
     cardNumberInstance: Field | undefined;
     securityCodeInstance: Field | undefined;
     expirationMonthInstance: Field | undefined;

--- a/src/bricks/brand/brand.test.tsx
+++ b/src/bricks/brand/brand.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MercadoPagoInstance } from '../../mercadoPago/initMercadoPago';
+import Brand from './index';
+
+describe('Test Brand Brick Component', () => {
+  test('should found the id of Brand Brick div', async () => {
+    MercadoPagoInstance.publicKey = 'PUBLIC_KEY';
+    const element = await render(<Brand />);
+
+    expect(element.container.querySelector('#brandBrick_container')).toBeTruthy();
+  });
+
+  test('should found the id of Brand Brick div', async () => {
+    MercadoPagoInstance.publicKey = 'PUBLIC_KEY';
+    const element = await render(
+      <Brand
+        customization={{
+          text: {
+            valueProp: 'payment_methods_logos',
+          },
+        }}
+        onReady={() => console.log('Brick is ready!')}
+      />,
+    );
+
+    expect(element.container.querySelector('#brandBrick_container')).toBeTruthy();
+  });
+});

--- a/src/bricks/brand/index.tsx
+++ b/src/bricks/brand/index.tsx
@@ -5,24 +5,24 @@ import { DEBOUNCE_TIME_RENDER } from '../util/constants';
 import { TBrand } from './types';
 
 /**
- * Wallet Brick allows you to offer payments from your Mercado Pago account at any stage of the purchase process.
+ * Brand Brick allows you to communicate different messages related to the payment methods available via Mercado Pago in your store.
  *
  * Usage:
  *
  * ```ts
- * import Wallet, {initMercadoPago} from '@mercadopago/sdk-react'
+ * import Brand, {initMercadoPago} from '@mercadopago/sdk-react'
  *
  * initMercadoPago('YOUR_PUBLIC_KEY')
  *
  * const Example = () => {
  *   return(
- *     <Wallet initialization={{ preferenceId: '<PREFERENCE_ID>'}} /> // PREFERENCE_ID generated in backend
+ *     <Brand />
  *   )
  * }
  * export default Example
  * ```
  *
- * @see {@link https://www.mercadopago.com/developers/en/docs/checkout-bricks/wallet-brick/introduction Wallet Brick documentation} for more information.
+ * @see {@link https://www.mercadopago.com/developers/en/docs/checkout-bricks/brand-brick/introduction Brand Brick documentation} for more information.
  */
 const Brand = ({
   onReady = onReadyDefault,

--- a/src/bricks/brand/index.tsx
+++ b/src/bricks/brand/index.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect } from 'react';
+import { onReadyDefault } from '../util/initial';
+import { initBrick } from '../util/renderBrick';
+import { DEBOUNCE_TIME_RENDER } from '../util/constants';
+import { TBrand } from './types';
+
+/**
+ * Wallet Brick allows you to offer payments from your Mercado Pago account at any stage of the purchase process.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import Wallet, {initMercadoPago} from '@mercadopago/sdk-react'
+ *
+ * initMercadoPago('YOUR_PUBLIC_KEY')
+ *
+ * const Example = () => {
+ *   return(
+ *     <Wallet initialization={{ preferenceId: '<PREFERENCE_ID>'}} /> // PREFERENCE_ID generated in backend
+ *   )
+ * }
+ * export default Example
+ * ```
+ *
+ * @see {@link https://www.mercadopago.com/developers/en/docs/checkout-bricks/wallet-brick/introduction Wallet Brick documentation} for more information.
+ */
+const Brand = ({
+  onReady = onReadyDefault,
+  customization,
+  locale,
+}: TBrand) => {
+  useEffect(() => {
+    // CardPayment uses a debounce to prevent unnecessary reRenders.
+    let timer: ReturnType<typeof setTimeout>;
+    const BrandBrickConfig = {
+      settings: {
+        customization,
+        locale,
+        callbacks: {
+          onReady: onReady,
+        },
+      },
+      name: 'brand',
+      divId: 'brandBrick_container',
+      controller: 'brandBrickController',
+    };
+
+    timer = setTimeout(() => {
+      initBrick(BrandBrickConfig);
+    }, DEBOUNCE_TIME_RENDER);
+
+    return () => {
+      clearTimeout(timer);
+      window.brandBrickController?.unmount();
+    };
+  }, [customization, onReady]);
+  return <div id="brandBrick_container"></div>;
+};
+
+export default Brand;

--- a/src/bricks/brand/readme.md
+++ b/src/bricks/brand/readme.md
@@ -1,0 +1,44 @@
+# Brand Brick
+
+## Content
+
+- [Brand Brick](#brand-brick)
+  - [Content](#content)
+  - [Intro](#intro)
+  - [How it works](#how-it-works)
+  - [How to use](#how-to-use)
+  - [External Links](#external-links)
+
+---
+
+## Intro
+
+Brand Brick communicates to the user advantages, conveniences, and information, such as: the available payment methods via Mercado Pago, accepted card networks, and the option to pay in installments with or without a credit card.
+
+---
+
+## How it works
+
+This is like a wrapper for the Brick. It breaks the main characterists - customizations and callback - in _props_ for the component. In this way it possible have a minimum impact if the Bricks change and take advantage of the already existent documentation.
+
+---
+
+## How to use
+
+```ts
+import Brand, { initMercadoPago } from '@mercadopago/sdk-react';
+
+initMercadoPago('YOUR_PUBLIC_KEY');
+
+const Example = () => {
+  return <Brand />;
+};
+
+export default Example;
+```
+
+---
+
+## External Links
+
+[Brand Brick official documentation](https://www.mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/introduction)

--- a/src/bricks/brand/types.ts
+++ b/src/bricks/brand/types.ts
@@ -1,12 +1,14 @@
 export type TBrand = {
   /**
    * Optional. An object containing customization options.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
    */
   customization?: IBrandCustomization;
   /**
-   * Optional. Function. Receives function to be executed just after brick rendered
+   * Optional. Function. Receives function to be executed just after brick rendered.
    *
-   * @see {@link https://www.mercadopago.com/developers/en/docs/checkout-bricks/card-payment-brick/default-rendering Card Payment Brick # Default rendering} documentation.
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/callbacksBrand Brick # Callbacks} documentation.
    */
   onReady?: () => void;
   /**
@@ -16,20 +18,65 @@ export type TBrand = {
    * @see {@link https://www.mercadopago.com/developers/en/docs/checkout-bricks/additional-content/select-language Bricks language customization} documentation.
    */
   locale?: 'es-AR' | 'es-CL' | 'es-CO' | 'es-MX' | 'es-VE' | 'es-UY' | 'es-PE' | 'pt-BR' | 'en-US';
-}
+};
 
 export interface IBrandCustomization {
+  /**
+   * Optional. Brand Brick offers some text customizations, such as: {align, valueProp, useCustomFont, size, fontWeight, color}
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   text?: IBrandText;
+  /**
+   * Optional. Brand Brick offers some visual customizations, such as: {hideMercadoPagoLogo, contentAlign, backgroundColor, border, borderColor, borderWidth, borderRadius, verticalPadding, horizontalPadding}
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   visual?: IBrandVisual;
+  /**
+   * Optional. Brand Brick offers some payment methods customizations, as: {excludedPaymentMethods, excludedPaymentTypes, maxInstallments, interestFreeInstallments}
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/payment-methods Brick # Payment methods} documentation.
+   */
   paymentMethods?: IBrandPaymentMethodCustomization;
 }
 
 export interface IBrandText {
+  /**
+   * Optional. There are four value propositions available that configure the content and can allow for certain customizations.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/default-rendering Brick # Value prop} documentation.
+   */
   valueProp?: BrandValueProps;
+  /**
+   * Optional. It starts false, but if it changes to true, Brick inherits the parent's font.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   useCustomFont?: boolean;
+  /**
+   * Optional. Changes the font size to one of the options provided.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   size?: BrandTextSizes;
+  /**
+   * Optional. Changes the font weight to one of the options provided.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   fontWeight?: BrandFontWeight;
+  /**
+   * Optional. Changes the font color to one of the options provided. Pay attention to the color contrast with the background color and allow the user to read the text.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   color?: BrandTextColor;
+  /**
+   * Optional. Changes the text alignment to one of the options provided.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   align?: BrandAlignment;
 }
 
@@ -49,14 +96,59 @@ type BrandTextColor = 'primary' | 'secondary' | 'inverted';
 type BrandAlignment = 'left' | 'center' | 'right';
 
 export interface IBrandVisual {
+  /**
+   * Optional. Hides the Mercado Pago logo from the banner.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   hideMercadoPagoLogo?: boolean;
+  /**
+   * Optional. Changes all the content alignment (text and logos, when the value prop applied have it) inside banner to one of the options provided.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   contentAlign?: BrandAlignment;
+  /**
+   * Optional. Changes banner background color to one of the options provided. Pay attention to the color contrast with the background color and allow the user to read the text.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   backgroundColor?: BrandBackgroundColor;
+  /**
+   * Optional. Enable border around banner.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   border?: boolean;
+  /**
+   * Optional. Changes banner border color to "dark" or "light".
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   borderColor?: BrandBorderColor;
+  /**
+   * Optional. Changes banner border width to 1px or 2px.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   borderWidth?: string;
+  /**
+   * Optional. Change the roundness of the banner border.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   borderRadius?: string;
+  /**
+   * Optional. Changes the vertical padding inside banner until 40px.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   verticalPadding?: string;
+  /**
+   * Optional. Changes the horizontal padding inside banner until 40px.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
+   */
   horizontalPadding?: string;
 }
 
@@ -70,9 +162,29 @@ type BrandBackgroundColor =
 type BrandBorderColor = 'dark' | 'light';
 
 export interface IBrandPaymentMethodCustomization {
+  /**
+   * Optional. Specify the payment methods you don't want to show.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/payment-methods Brick # Payment methods} documentation.
+   */
   excludedPaymentMethods?: TBrandPaymentMethods[];
+  /**
+   * Optional. Specify the payment types you don't want to show.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/payment-methods Brick # Payment methods} documentation.
+   */
   excludedPaymentTypes?: TBrandPaymentTypes[];
+  /**
+   * Optional. Add an installment limit.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/payment-methods Brick # Payment methods} documentation.
+   */
   maxInstallments?: number;
+  /**
+   * Optional. If true, the installments will be presented interest-free.
+   *
+   * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/payment-methods Brick # Payment methods} documentation.
+   */
   interestFreeInstallments?: boolean;
 }
 

--- a/src/bricks/brand/types.ts
+++ b/src/bricks/brand/types.ts
@@ -44,6 +44,7 @@ export interface IBrandCustomization {
 export interface IBrandText {
   /**
    * Optional. There are four value propositions available that configure the content and can allow for certain customizations.
+   * {'installments', 'payment_methods', 'security', 'payment_methods_logos', 'credits'}.
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/default-rendering Brick # Value prop} documentation.
    */
@@ -56,24 +57,28 @@ export interface IBrandText {
   useCustomFont?: boolean;
   /**
    * Optional. Changes the font size to one of the options provided.
+   * {'extra_small', 'small', 'medium', 'large'}.
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
    */
   size?: BrandTextSizes;
   /**
    * Optional. Changes the font weight to one of the options provided.
+   * {'regular', 'semibold'}.
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
    */
   fontWeight?: BrandFontWeight;
   /**
    * Optional. Changes the font color to one of the options provided. Pay attention to the color contrast with the background color and allow the user to read the text.
+   * {'primary', 'secondary', 'inverted'}.
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
    */
   color?: BrandTextColor;
   /**
    * Optional. Changes the text alignment to one of the options provided.
+   * {'left', 'center', 'right'}.
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
    */
@@ -104,12 +109,14 @@ export interface IBrandVisual {
   hideMercadoPagoLogo?: boolean;
   /**
    * Optional. Changes all the content alignment (text and logos, when the value prop applied have it) inside banner to one of the options provided.
+   * {'left', 'center', 'right'}.
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
    */
   contentAlign?: BrandAlignment;
   /**
    * Optional. Changes banner background color to one of the options provided. Pay attention to the color contrast with the background color and allow the user to read the text.
+   * {'white', 'mercado_pago_primary', 'mercado_pago_secondary', 'black', 'transparent'}.
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
    */
@@ -121,7 +128,8 @@ export interface IBrandVisual {
    */
   border?: boolean;
   /**
-   * Optional. Changes banner border color to "dark" or "light".
+   * Optional. Changes banner border color to 'dark' or 'light'.
+   * {'dark', 'light'}
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/visual-customizations Brick # Visual customizations} documentation.
    */
@@ -164,12 +172,14 @@ type BrandBorderColor = 'dark' | 'light';
 export interface IBrandPaymentMethodCustomization {
   /**
    * Optional. Specify the payment methods you don't want to show.
+   * ['master', 'visa', 'amex', 'naranja', 'maestro', 'cabal', 'cencosud', 'cordobesa', 'argencard', 'diners', 'tarshop', 'cmr', 'rapipago', 'pagofacil', 'mercadopago']
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/payment-methods Brick # Payment methods} documentation.
    */
   excludedPaymentMethods?: TBrandPaymentMethods[];
   /**
    * Optional. Specify the payment types you don't want to show.
+   * ['credit_card', 'debit_card', 'ticket', 'account_money', 'mercado_credito'].
    *
    * @see {@link https://mercadopago.com.ar/developers/en/docs/checkout-bricks/brand-brick/settings/payment-methods Brick # Payment methods} documentation.
    */

--- a/src/bricks/brand/types.ts
+++ b/src/bricks/brand/types.ts
@@ -1,0 +1,101 @@
+export type TBrand = {
+  /**
+   * Optional. An object containing customization options.
+   */
+  customization?: IBrandCustomization;
+  /**
+   * Optional. Function. Receives function to be executed just after brick rendered
+   *
+   * @see {@link https://www.mercadopago.com/developers/en/docs/checkout-bricks/card-payment-brick/default-rendering Card Payment Brick # Default rendering} documentation.
+   */
+  onReady?: () => void;
+  /**
+   * Optional. Language selection for the Brick, options are:
+   * {pt, es, es-AR, es-MX, es-UY, es-PE, es-CL, es-CO, en}
+   *
+   * @see {@link https://www.mercadopago.com/developers/en/docs/checkout-bricks/additional-content/select-language Bricks language customization} documentation.
+   */
+  locale?: 'es-AR' | 'es-CL' | 'es-CO' | 'es-MX' | 'es-VE' | 'es-UY' | 'es-PE' | 'pt-BR' | 'en-US';
+}
+
+export interface IBrandCustomization {
+  text?: IBrandText;
+  visual?: IBrandVisual;
+  paymentMethods?: IBrandPaymentMethodCustomization;
+}
+
+export interface IBrandText {
+  valueProp?: BrandValueProps;
+  useCustomFont?: boolean;
+  size?: BrandTextSizes;
+  fontWeight?: BrandFontWeight;
+  color?: BrandTextColor;
+  align?: BrandAlignment;
+}
+
+type BrandValueProps =
+  | 'installments'
+  | 'payment_methods'
+  | 'security'
+  | 'payment_methods_logos'
+  | 'credits';
+
+type BrandTextSizes = 'extra_small' | 'small' | 'medium' | 'large';
+
+type BrandFontWeight = 'regular' | 'semibold';
+
+type BrandTextColor = 'primary' | 'secondary' | 'inverted';
+
+type BrandAlignment = 'left' | 'center' | 'right';
+
+export interface IBrandVisual {
+  hideMercadoPagoLogo?: boolean;
+  contentAlign?: BrandAlignment;
+  backgroundColor?: BrandBackgroundColor;
+  border?: boolean;
+  borderColor?: BrandBorderColor;
+  borderWidth?: string;
+  borderRadius?: string;
+  verticalPadding?: string;
+  horizontalPadding?: string;
+}
+
+type BrandBackgroundColor =
+  | 'white'
+  | 'mercado_pago_primary'
+  | 'mercado_pago_secondary'
+  | 'black'
+  | 'transparent';
+
+type BrandBorderColor = 'dark' | 'light';
+
+export interface IBrandPaymentMethodCustomization {
+  excludedPaymentMethods?: TBrandPaymentMethods[];
+  excludedPaymentTypes?: TBrandPaymentTypes[];
+  maxInstallments?: number;
+  interestFreeInstallments?: boolean;
+}
+
+type TBrandPaymentMethods =
+  | 'master'
+  | 'visa'
+  | 'amex'
+  | 'naranja'
+  | 'maestro'
+  | 'cabal'
+  | 'cencosud'
+  | 'cordobesa'
+  | 'argencard'
+  | 'diners'
+  | 'tarshop'
+  | 'cmr'
+  | 'rapipago'
+  | 'pagofacil'
+  | 'mercadopago';
+
+type TBrandPaymentTypes =
+  | 'credit_card'
+  | 'debit_card'
+  | 'ticket'
+  | 'account_money'
+  | 'mercado_credito';


### PR DESCRIPTION
Adding Brand Brick at sdk-react.

To test, run this branch with "npm run start" and validates simple and customizations view
<img width="811" alt="Captura de Tela 2023-12-18 às 18 09 27" src="https://github.com/mercadopago/sdk-react/assets/111452934/c7f036a1-663e-4ea7-9cb0-c0305e76c03e">

<img width="920" alt="Captura de Tela 2023-12-18 às 18 09 35" src="https://github.com/mercadopago/sdk-react/assets/111452934/d407e86a-25cf-436a-8134-32afc46dcc14">
