### PR TITLE
Fix core-methods export docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is a wrapper that allows integrate [Checkout Bricks](https://www.mercadopag
 
 ## Prerequisites
 
-Before starts verify if you have installed Node version `14.18.0` or superior.
+Before starts verify if you have installed Node version `v16.20.2` or superior.
 
 <br/>
 
@@ -315,7 +315,7 @@ const installments = await getInstallments({
 Return a token card
 
 ```javascript
-import { createCardToken } from '@mercadopago/sdk-react/coreMethods';
+import { createCardToken } from '@mercadopago/sdk-react/esm/coreMethods';
 const cardToken = await createCardToken({
   cardNumber: '<CREDIT_CARD_NUMBER>',
   cardholderName: '<CARDHOLDER_NAME>',
@@ -326,6 +326,8 @@ const cardToken = await createCardToken({
   identificationNumber: '<BUYER_IDENTIFICATION_NUMBER>',
 });
 ```
+
+> When importing directly from `/coreMethods`, you have to explicitly choose between the `/esm` or `/cjs` export formats. For example, use `import { createCardToken } from '@mercadopago/sdk-react/esm/coreMethods';` for ECMAScript modules, or `const { createCardToken } = require('@mercadopago/sdk-react/cjs/coreMethods');` for CommonJS modules. For root imports, this selection is not necessary.
 
 ## Run SDK project
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mercadopago/sdk-react",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mercadopago/sdk-react",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "license": "Apache-2.0",
       "dependencies": {
         "@mercadopago/sdk-js": "^0.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercadopago/sdk-react",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Mercado Pago SDK React",
   "main": "cjs/index.js",
   "module": "esm/index.js",


### PR DESCRIPTION

## Description 
With the changes introduced on [this commit](https://github.com/mercadopago/sdk-react/commit/a9763534e5e2879075225e4e3b91b9a1e1693c85), the `dist` folder where split into  `/esm` and `/cjs`. Therefore, for not direct imports, the user must inform from each folder the module should be imported.

The documentation was updated to inform that need