### PR TITLE
fix: remove brand wallet prop

### DIFF
--- a/src/bricks/wallet/index.tsx
+++ b/src/bricks/wallet/index.tsx
@@ -30,7 +30,6 @@ const Wallet = ({
   onSubmit = onSubmitDefault as () => Promise<unknown>,
   customization,
   initialization,
-  brand,
   locale,
   id = 'walletBrick_container',
 }: TWallet) => {
@@ -39,7 +38,6 @@ const Wallet = ({
 
     const WalletBrickConfig = {
       settings: {
-        brand,
         initialization,
         customization,
         locale,


### PR DESCRIPTION
This prop was added to Wallet Brick 1 year ([PR](https://github.com/mercadopago/sdk-react/pull/93)) ago and recently was removed from types, but not from .tsx. This PR resolves it