### PR TITLE
fix: add index to coreMethods to resolve imports

### DIFF
--- a/src/coreMethods/index.ts
+++ b/src/coreMethods/index.ts
@@ -1,0 +1,7 @@
+import createCardToken from "./cardToken/create";
+import updateCardToken from "./cardToken/update";
+import getIdentificationTypes from "./getIdentificationTypes";
+import getInstallments from "./getInstallments";
+import getIssuers from "./getIssuers";
+import getPaymentMethods from "./getPaymentMethods";
+export { createCardToken, updateCardToken, getIdentificationTypes, getInstallments, getIssuers, getPaymentMethods };


### PR DESCRIPTION
Before

![image](https://github.com/user-attachments/assets/a0b1e003-92e9-449a-8b7c-dfd3c83c9378)

After

![image](https://github.com/user-attachments/assets/95512806-74a5-43e5-b16b-89e62cd8f12e)

Then, it's expected as output: `index.d.ts` and `index.js` at build time inside `esm/coreMethods`.